### PR TITLE
feat: ignore .env* files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env*
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
This commit adds `.env*` to the `.gitignore` file, preventing sensitive environment variables from being committed to the repository.